### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/satan_encryptor.py
+++ b/satan_encryptor.py
@@ -1120,7 +1120,7 @@ class CryptoTab(BaseTab):
             else:
                 raise ValueError("Unsupported key file extension. Use .pem or .key")
         except Exception as e:
-            logger.error(f"Error loading key from file {key_file_path}: {e}")
+            logger.error(f"Error loading key from file '{os.path.basename(key_file_path)}': {e}")
             raise ValueError(f"Failed to load key from file: {e}")
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Suryabx/Satan-Encryptor/security/code-scanning/2](https://github.com/Suryabx/Satan-Encryptor/security/code-scanning/2)

To fix the problem, we should avoid logging sensitive data such as passwords or sensitive file paths. In this case, the error message logs the full `key_file_path`, which may be sensitive. The best fix is to log only non-sensitive information, such as the base filename (using `os.path.basename(key_file_path)`) or a generic error message without including the path. This preserves useful debugging information (e.g., which file failed) without exposing the full path or any sensitive data. The change should be made only to the error logging line in `_load_key_from_file` (line 1123). No new imports are needed, as `os.path.basename` is already available.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
